### PR TITLE
HAL_F4Light: Fix inverter on Omnibus F4 V3

### DIFF
--- a/libraries/AP_HAL_F4Light/boards/f4light_AirbotV2/board.cpp
+++ b/libraries/AP_HAL_F4Light/boards/f4light_AirbotV2/board.cpp
@@ -195,10 +195,14 @@ void boardInit(void) {
     gpio_set_mode(PIN_MAP[BOARD_MPU6000_DRDY_PIN].gpio_device, PIN_MAP[BOARD_MPU6000_DRDY_PIN].gpio_bit, GPIO_INPUT_PU);
 #endif
 
-#ifdef BOARD_SBUS_INVERTER
-// it is not necessary because of 10K resistor to ground
-    gpio_set_mode( PIN_MAP[BOARD_SBUS_INVERTER].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER].gpio_bit, GPIO_OUTPUT_PP);
-    gpio_write_bit(PIN_MAP[BOARD_SBUS_INVERTER].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER].gpio_bit, 0); // not inverted
+#ifdef BOARD_SBUS_INVERTER_RX
+    gpio_set_mode( PIN_MAP[BOARD_SBUS_INVERTER_RX].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER_RX].gpio_bit, GPIO_OUTPUT_PP);
+    gpio_write_bit(PIN_MAP[BOARD_SBUS_INVERTER_RX].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER_RX].gpio_bit, 0); // not inverted
+#endif
+
+#ifdef BOARD_SBUS_INVERTER_TX
+    gpio_set_mode( PIN_MAP[BOARD_SBUS_INVERTER_TX].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER_TX].gpio_bit, GPIO_OUTPUT_PP);
+    gpio_write_bit(PIN_MAP[BOARD_SBUS_INVERTER_TX].gpio_device, PIN_MAP[BOARD_SBUS_INVERTER_TX].gpio_bit, 0); // not inverted
 #endif
 
 }

--- a/libraries/AP_HAL_F4Light/boards/f4light_AirbotV2/board.h
+++ b/libraries/AP_HAL_F4Light/boards/f4light_AirbotV2/board.h
@@ -67,14 +67,11 @@
 #define BOARD_MPU6000_CS_PIN	51
 #define BOARD_MPU6000_DRDY_PIN	10  // PC4
 
-//#define BOARD_SBUS_INVERTER     6
+#define BOARD_SBUS_INVERTER_RX     14
+#define BOARD_SBUS_INVERTER_TX     15
+
 
 #define BOARD_USB_SENSE 11      // PC5
-
-
-// bus 2 (soft) pins
-#define BOARD_SOFT_SCL 14
-#define BOARD_SOFT_SDA 15
 
 // SoftSerial pins
 //#define BOARD_SOFTSERIAL_TX 14


### PR DESCRIPTION
Omnibus F4 V3 has bidirectional inverter on uart6, controlled by PC8, PC9. Other versions have this pins connected to small pad on PCB and are usually unused.