### PR TITLE
Libraries: Fixed I2C initalization for Airspeed sensor on MatekF405CTR

### DIFF
--- a/libraries/AP_HAL_F4Light/I2CDevice.cpp
+++ b/libraries/AP_HAL_F4Light/I2CDevice.cpp
@@ -187,12 +187,15 @@ void I2CDevice::init(){
     if(_dev) {
         i2c_init(_dev, _offs, _slow?I2C_250KHz_SPEED:I2C_400KHz_SPEED);
 
-    }else {
+    }else if (s_i2c){
         s_i2c->init( );
 
         if(_slow) {
             s_i2c->set_low_speed(true);
         }
+    }
+    else { // neither hardware nor software initalization was successful
+        return;
     }
     _initialized=true;
 }


### PR DESCRIPTION
This should fix: [Arduplane not work on Matek F405 CTR #15](https://github.com/night-ghost/ardupilot/issues/15)

By default arduplane uses the MS4525 airspeed sensor. During the initialization the airspeed sensor tries to establish a communication on I2C Bus 0, 1 and 2.
At the moment I2CDevices.cpp can not handle I2C bus 2 initalization if SoftI2C is undefined.  
This PR should fix this issue.
Tests done: Communication between APM Planner 2 and Matek F405 CTR board for Arduplane and Arducopter.